### PR TITLE
Send in Avro JSON encoding format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
 install: "pip install mock==1.3.0 nose==1.3.7"
 script: python setup.py test
 notifications:

--- a/kafka_rest/producer.py
+++ b/kafka_rest/producer.py
@@ -105,12 +105,12 @@ class AsyncProducer(object):
 
     def _handle_produce_success(self, topic, response, response_body):
         # Store schema IDs if we haven't already
-        if not isinstance(self.client.schema_cache['value'][topic], int):
+        if self.client.schema_cache[topic].get('value-id') is None:
             logger.debug('Storing value schema ID of {0} for topic {1}'.format(response_body['value_schema_id'], topic))
-            self.client.schema_cache['value'][topic] = response_body['value_schema_id']
-        if response_body.get('key_schema_id') and not isinstance(self.client.schema_cache['key'].get(topic), int):
+            self.client.schema_cache[topic]['value-id'] = response_body['value_schema_id']
+        if response_body.get('key_schema_id') and self.client.schema_cache[topic].get('key-id') is None:
             logger.debug('Storing key schema ID of {0} for topic {1}'.format(response_body['key_schema_id'], topic))
-            self.client.schema_cache['key'][topic] = response_body['key_schema_id']
+            self.client.schema_cache[topic]['key-id'] = response_body['key_schema_id']
 
         # Individual requests could still have failed, need to check
         # each response object's error code

--- a/kafka_rest/rest_proxy.py
+++ b/kafka_rest/rest_proxy.py
@@ -1,5 +1,7 @@
 from tornado.httpclient import HTTPRequest
 from tornado.escape import json_encode
+import avro.schema
+from avro_json_serializer import AvroJsonSerializer
 
 ERROR_CODES = {
     40401: 'Topic not found',
@@ -16,34 +18,44 @@ ERROR_CODES = {
 # See https://github.com/confluentinc/kafka-rest/issues/147
 RETRIABLE_ERROR_CODES = set([50001, 50002, 50003])
 
+def _encode_payload(schema_cache, topic, batch):
+    value_schema = avro.schema.make_avsc_object(schema_cache[topic]['value'], avro.schema.Names())
+    value_serializer = AvroJsonSerializer(value_schema)
+    if schema_cache[topic].get('key') is not None:
+        key_schema = avro.schema.make_avsc_object(schema_cache[topic]['key'], avro.schema.Names())
+        key_serializer = AvroJsonSerializer(key_schema)
+
+    body = {'records': [{'value': value_serializer.to_ordered_dict(message.value),
+                         'key': key_serializer.to_ordered_dict(message.key) if message.key is not None else None,
+                         'partition': message.partition}
+                        for message in batch]}
+
+    # The REST proxy's API requires us to double-encode the schemas.
+    # Don't ask why, because I have no idea.
+    if schema_cache[topic].get('value-id') is None:
+        body['value_schema'] = json_encode(schema_cache[topic]['value'])
+    else:
+        body['value_schema_id'] = schema_cache[topic]['value-id']
+    if schema_cache[topic].get('key') is not None:
+        if schema_cache[topic].get('key-id') is None:
+            body['key_schema'] = json_encode(schema_cache[topic]['key'])
+        else:
+            body['key_schema_id'] = schema_cache[topic]['key-id']
+
+    return json_encode(body)
+
 def request_for_batch(host, port, connect_timeout, request_timeout,
                       schema_cache, topic, batch):
     """Returns a Tornado HTTPRequest to the REST proxy
     representing the given message batch. This does not
     send the request, it just creates the object."""
-    body = {'records': [{'value': message.value, 'key': message.key, 'partition': message.partition}
-                        for message in batch]}
-
-    # The REST proxy's API requires us to double-encode the schemas.
-    # Don't ask why, because I have no idea.
-    value_schema, key_schema = schema_cache['value'][topic], schema_cache['key'].get(topic)
-    if isinstance(value_schema, dict):
-        body['value_schema'] = json_encode(value_schema)
-    else:
-        body['value_schema_id'] = value_schema
-    if key_schema:
-        if isinstance(key_schema, dict):
-            body['key_schema'] = json_encode(key_schema)
-        else:
-            body['key_schema_id'] = key_schema
-
     request = HTTPRequest('{0}:{1}/topics/{2}'.format(host, port, topic),
                           connect_timeout=connect_timeout,
                           request_timeout=request_timeout,
                           method='POST',
                           headers={'Accept': 'application/vnd.kafka.v1+json',
                                    'Content-Type': 'application/vnd.kafka.avro.v1+json'},
-                          body=json_encode(body))
+                          body=_encode_payload(schema_cache, topic, batch))
 
     # We also stick the message batch on the HTTPRequest object itself
     # so it is available to us when we handle the response. This is necessary

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,9 @@ from kafka_rest import __version__
 
 install_requires = [
     'tornado>=4.0.0,<5.0.0',
-    'avro_json_serializer>=0.4.1,<0.5.0'
+    'avro_json_serializer>=0.4.1,<0.5.0',
+    'avro==1.7.7'
 ]
-
-# TODO: Be more liberal with Avro versions
-if sys.version_info[0] >= 3:
-    install_requires.append('avro-python3==1.7.7')
-else:
-    install_requires.append('avro==1.7.7')
 
 setup(
     name='kafka-rest',

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,16 @@ setup(
     author='GameChanger',
     author_email='travis@gc.io',
     packages=find_packages(),
-    install_requires=['tornado>=4.0.0,<5.0.0'],
-    tests_require=['mock==1.3.0', 'nose==1.3.7'],
+    install_requires=[
+        'tornado>=4.0.0,<5.0.0',
+        'avro_json_serializer>=0.4.1,<0.5.0',
+        # TODO: Avro version req should be more liberal
+        'avro==1.7.7'
+    ],
+    tests_require=[
+        'mock==1.3.0',
+        'nose==1.3.7'
+    ],
     test_suite="nose.collector",
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,18 @@
+import sys
 from setuptools import setup, find_packages
 
 from kafka_rest import __version__
+
+install_requires = [
+    'tornado>=4.0.0,<5.0.0',
+    'avro_json_serializer>=0.4.1,<0.5.0'
+]
+
+# TODO: Be more liberal with Avro versions
+if sys.version_info[0] >= 3:
+    install_requires.append('avro-python3==1.7.7')
+else:
+    install_requires.append('avro==1.7.7')
 
 setup(
     name='kafka-rest',
@@ -10,12 +22,7 @@ setup(
     author='GameChanger',
     author_email='travis@gc.io',
     packages=find_packages(),
-    install_requires=[
-        'tornado>=4.0.0,<5.0.0',
-        'avro_json_serializer>=0.4.1,<0.5.0',
-        # TODO: Avro version req should be more liberal
-        'avro==1.7.7'
-    ],
+    install_requires=install_requires,
     tests_require=[
         'mock==1.3.0',
         'nose==1.3.7'

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -34,8 +34,8 @@ class TestClient(TestCase):
         self.client.produce('test_driver', self.test_value, self.test_schema)
         expected_message = Message('test_driver', self.test_value, None, None, 0, 1)
 
-        self.assertEqual(self.client.schema_cache['value']['test_driver'], self.test_schema)
-        self.assertEqual(None, self.client.schema_cache['key'].get('test_driver'))
+        self.assertEqual(self.client.schema_cache['test_driver']['value'], self.test_schema)
+        self.assertEqual(None, self.client.schema_cache['test_driver'].get('key'))
         self.assertEqual(1, self.client.message_queues['test_driver'].qsize())
         self.client.mock_for('produce').assert_called_once_with(expected_message)
         self.callback_mock.assert_called_once_with(self.client.producer.evaluate_queue,

--- a/tests/producer_test.py
+++ b/tests/producer_test.py
@@ -26,8 +26,8 @@ class TestProducer(TestCase):
         }
         self.test_value = {'val': 1}
 
-        self.client.schema_cache['value']['test_driver'] = 1
-        self.client.schema_cache['key']['test_driver'] = 2
+        self.client.schema_cache['test_driver']['value-id'] = 1
+        self.client.schema_cache['test_driver']['key-id'] = 2
 
     def tearDown(self):
         if not self.client.in_shutdown:
@@ -128,13 +128,13 @@ class TestProducer(TestCase):
                                                                      'max_retries_exceeded')
 
     def test_handle_produce_success_stores_value_schema_id(self):
-        self.client.schema_cache['value']['test_driver'] = None
+        self.client.schema_cache['test_driver']['value-id'] = None
         body = {'offsets': [], 'value_schema_id': 5, 'key_schema_id': 2}
 
         self.producer._handle_produce_success('test_driver', None, body)
 
-        self.assertEqual(self.client.schema_cache['value']['test_driver'], 5)
-        self.assertEqual(self.client.schema_cache['key']['test_driver'], 2)
+        self.assertEqual(self.client.schema_cache['test_driver']['value-id'], 5)
+        self.assertEqual(self.client.schema_cache['test_driver']['key-id'], 2)
 
     def test_handle_produce_success_simple_success(self):
         m1 = Message('test_driver', {'val': 1}, None, None, 0, 1)


### PR DESCRIPTION
@paetling Two things here:

1. Added LinkedIn's JSON encoder so we can send union types to the proxy correctly
2. Refactored the schema cache to always keep the full version of the schema around since we need that for the JSON encoding