### PR TITLE
Handle 5xxs specifically instead of any HTTP error

### DIFF
--- a/kafka_rest/producer.py
+++ b/kafka_rest/producer.py
@@ -56,7 +56,7 @@ class AsyncProducer(object):
     def _start_retries(self):
         """Go through all the retry queues and schedule produce callbacks
         for all messages that are due to be retried."""
-        if self.client.transport_circuit_breaker.tripped:
+        if self.client.response_5xx_circuit_breaker.tripped:
             logger.debug('Transport circuit breaker is tripped, skipping retry pass')
             self.client.registrar.emit('circuit_breaker.retries')
             return
@@ -144,25 +144,21 @@ class AsyncProducer(object):
     def _handle_produce_response(self, topic, response):
         del self.inflight_requests[response.request._id]
 
-        # First, we check for a transport error
-        if response.error:
-            logger.error('Transport error submitting batch to topic {0}: {1}'.format(topic, response.error))
-            self.client.transport_circuit_breaker.record_failure()
-            self.client.registrar.emit('transport_error', topic, response.error)
-            for message in response.request._batch:
-                self._queue_message_for_retry(topic, message)
-            return
+        if response.code != 599:
+            response_body = json_decode(response.body)
+            error_code, error_message = response_body.get('error_code'), response_body.get('message')
 
-        # We should have gotten a well-formed response back from the
-        # proxy if we got this far
-        self.client.transport_circuit_breaker.reset()
-        response_body = json_decode(response.body)
-        error_code, error_message = response_body.get('error_code'), response_body.get('message')
+        if response.code >= 500:
+            logger.error('Received {0} response submitting batch to topic {1}: {2}'.format(response.code, topic, response.error))
+            self.client.response_5xx_circuit_breaker.record_failure()
+            self.client.registrar.emit('response_5xx', topic, response)
+        else:
+            self.client.response_5xx_circuit_breaker.reset()
 
         if response.code == 200:
             self._handle_produce_success(topic, response, response_body)
         else: # We failed somehow, more information in the error code
-            if error_code in RETRIABLE_ERROR_CODES:
+            if response.code == 599 or error_code in RETRIABLE_ERROR_CODES:
                 for message in response.request._batch:
                     self._queue_message_for_retry(topic, message)
             else: # Non-retriable failure of entire request
@@ -170,7 +166,7 @@ class AsyncProducer(object):
                     self.client.registrar.emit('drop_message', topic, message, DropReason.NONRETRIABLE)
 
     def _flush_topic(self, topic, reason):
-        if self.client.transport_circuit_breaker.tripped:
+        if self.client.response_5xx_circuit_breaker.tripped:
             logger.debug('Transport circuit breaker is tripped, skipping flush topic')
             self.client.registrar.emit('circuit_breaker.flush_topic', topic, reason)
         else:
@@ -203,7 +199,7 @@ class AsyncProducer(object):
         # Last-ditch send attempts on remaining messages. These will use
         # shorter shutdown timeouts on the request in order to finish
         # by the time we invoke _finish_shutdown
-        self.client.transport_circuit_breaker.reset()
+        self.client.response_5xx_circuit_breaker.reset()
         IOLoop.current().add_callback(self._start_retries)
         for topic, queue in self.client.message_queues.items():
             if not queue.empty():

--- a/tests/flow_test.py
+++ b/tests/flow_test.py
@@ -155,7 +155,7 @@ class TestFlow(TestCase):
 
     def test_response_through_success_with_transport_error(self):
         response = self.make_response(
-            response_attrs={'error': 'anything truthy'})
+            response_attrs={'code': 599})
 
         self.producer._handle_produce_response('test_driver', response)
 


### PR DESCRIPTION
@paetling I misunderstood the `response.error` object before. This gets set for any error status code, not only for transport errors. This PR changes that circuit breaker to act explicitly on 5xx responses, and also changes the response logic around a bit to accommodate that. I might still break this up into topic-level breakers, just wanted to do this as a single unit first.