### PR TITLE
Add TRACE level logging, move most DEBUG logs over to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ the `IOLoop` for too long.
 
 TODO: Enumerate these in a separate Hooks.md file
 
+## Logging
+
+In addition to standard debug-level logging, the client emits very detailed logs
+at a custom TRACE level. To configure your root logger to show the TRACE logs,
+run the following:
+
+```python
+import logging
+logging.getLogger().setLevel(5)
+```
+
 ## Limitations
 
 * No consumer support

--- a/kafka_rest/client.py
+++ b/kafka_rest/client.py
@@ -1,5 +1,4 @@
 import sys
-import logging
 from threading import Thread
 try:
     from queue import Queue, PriorityQueue, Full
@@ -14,8 +13,9 @@ from .circuit_breaker import CircuitBreaker
 from .producer import AsyncProducer
 from .message import Message
 from .exceptions import KafkaRESTShutdownException
+from .custom_logging import getLogger
 
-logger = logging.getLogger('kafka_rest.client')
+logger = getLogger('kafka_rest.client')
 
 class KafkaRESTClient(object):
     def __init__(self, host, port, http_max_clients=10, max_queue_size_per_topic=5000,
@@ -79,10 +79,10 @@ class KafkaRESTClient(object):
             raise KafkaRESTShutdownException('Client is in shutdown state, new events cannot be produced')
 
         if self.schema_cache[topic].get('value') is None:
-            logger.debug('Storing initial value schema for topic {0} in schema cache: {1}'.format(topic, value_schema))
+            logger.trace('Storing initial value schema for topic {0} in schema cache: {1}'.format(topic, value_schema))
             self.schema_cache[topic]['value'] = value_schema
         if key_schema and self.schema_cache[topic].get('key') is None:
-            logger.debug('Storing initial key schema for topic {0} in schema cache: {1}'.format(topic, key_schema))
+            logger.trace('Storing initial key schema for topic {0} in schema cache: {1}'.format(topic, key_schema))
             self.schema_cache[topic]['key'] = key_schema
 
         queue = self.message_queues[topic]

--- a/kafka_rest/custom_logging.py
+++ b/kafka_rest/custom_logging.py
@@ -13,5 +13,7 @@ def _trace(self, msg, *args, **kwargs):
 def getLogger(name):
     logger = logging.getLogger(name)
 
-    logger.trace = types.MethodType(_trace, logger)
+    if not hasattr(logger, 'trace'):
+        logger.trace = types.MethodType(_trace, logger)
+
     return logger

--- a/kafka_rest/custom_logging.py
+++ b/kafka_rest/custom_logging.py
@@ -1,0 +1,17 @@
+"""Adds TRACE level logging, which is below DEBUG."""
+
+import logging
+import types
+
+TRACE_LEVEL = 5
+
+logging.addLevelName(TRACE_LEVEL, 'TRACE')
+
+def _trace(self, msg, *args, **kwargs):
+    self.log(TRACE_LEVEL, msg, *args, **kwargs)
+
+def getLogger(name):
+    logger = logging.getLogger(name)
+
+    logger.trace = types.MethodType(_trace, logger)
+    return logger

--- a/kafka_rest/events.py
+++ b/kafka_rest/events.py
@@ -1,7 +1,8 @@
-import logging
 from collections import defaultdict
 
-logger = logging.getLogger('kafka_rest.events')
+from .custom_logging import getLogger
+
+logger = getLogger('kafka_rest.events')
 
 class FlushReason(object):
     LENGTH = 'length'
@@ -28,7 +29,7 @@ class EventRegistrar(object):
 
     def emit(self, event, *args, **kwargs):
         if self.debug:
-            logger.debug('Event: {0} Args: {1} Kwargs: {2}'.format(event, args, kwargs))
+            logger.trace('Event: {0} Args: {1} Kwargs: {2}'.format(event, args, kwargs))
         for handler in self.handlers[event]:
             try:
                 handler(*args, **kwargs)


### PR DESCRIPTION
review @paetling 

The driver tends to log *a ton* under debug, particularly when it is handling many topics. Many of these logs are very specific, very large (contain massive payloads), and only useful for debugging certain classes of problems. This PR creates a new TRACE level below Python's standard DEBUG, then moves many of the more verbose logging statements to TRACE level.

This will allow apps to continue operating under standard DEBUG level (as our staging applications do) without completely flooding them with messages from this driver or requiring custom level handling just for the driver.